### PR TITLE
🐛 fix(data): remove erroneous suffix from account 6037 label

### DIFF
--- a/versions/2025/pcg_2025.json
+++ b/versions/2025/pcg_2025.json
@@ -3087,7 +3087,7 @@
         },
         {
             "number": 6037,
-            "label": "Variation des stocks de marchandises 61/62 Autres charges externes",
+            "label": "Variation des stocks de marchandises",
             "system": "minimal",
             "parent": 603
         },
@@ -8252,7 +8252,7 @@
                                 },
                                 {
                                     "number": 6037,
-                                    "label": "Variation des stocks de marchandises 61/62 Autres charges externes",
+                                    "label": "Variation des stocks de marchandises",
                                     "system": "minimal",
                                     "accounts": []
                                 }
@@ -15997,7 +15997,7 @@
                 "number": 6037,
                 "label": {
                     "from": "Variation des stocks de marchandises",
-                    "to": "Variation des stocks de marchandises 61/62 Autres charges externes"
+                    "to": "Variation des stocks de marchandises"
                 },
                 "system": {
                     "from": "base",

--- a/versions/2026/pcg_2026.json
+++ b/versions/2026/pcg_2026.json
@@ -3087,7 +3087,7 @@
         },
         {
             "number": 6037,
-            "label": "Variation des stocks de marchandises 61/62 Autres charges externes",
+            "label": "Variation des stocks de marchandises",
             "system": "minimal",
             "parent": 603
         },
@@ -8250,7 +8250,7 @@
                                 },
                                 {
                                     "number": 6037,
-                                    "label": "Variation des stocks de marchandises 61/62 Autres charges externes",
+                                    "label": "Variation des stocks de marchandises",
                                     "system": "minimal",
                                     "accounts": []
                                 }


### PR DESCRIPTION
- remove trailing "61/62 Autres charges externes" from account 6037 "Variation des stocks de marchandises" in 2025 and 2026 versions
- fix affected occurrences in accounts list, hierarchy, and changelog sections of pcg_2025.json and pcg_2026.json